### PR TITLE
Fix previous month errors

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -104,7 +104,7 @@ function getMonthOffset(date, offset) {
     offsetMonth -= 12;
     newDate.setFullYear(date.getFullYear() + 1);
   }
-  newDate.setMonth(offsetMonth);
+  newDate.setMonth(offsetMonth, 1);
   return newDate;
 }
 var getMonthOffset_default = getMonthOffset;

--- a/src/getMonthOffset.ts
+++ b/src/getMonthOffset.ts
@@ -8,7 +8,7 @@ function getMonthOffset(date: Date, offset: number): Date {
     offsetMonth -= 12;
     newDate.setFullYear(date.getFullYear() + 1);
   }
-  newDate.setMonth(offsetMonth);
+  newDate.setMonth(offsetMonth, 1);
   return newDate;
 }
 export default getMonthOffset;


### PR DESCRIPTION
In the current version, if today is the July 31, there are two "today" dates and June has 31 days (see the attached image).
It happens because when you try to use `.setMonth` with the previous month on July 31, it tries to set it to June 31 and it doesn't exist. So I `.setMonth` to the first day of the month, it should work fine.

![photo_2023-07-31_22-25-37](https://github.com/rudotriton/scriptable-calendar-widget/assets/10670765/82749695-211c-4009-bead-b8b82ad1c722)

p.s.: awesome script :)
